### PR TITLE
feat: 공부방(StudyRoom) 도메인 TanStack Query 훅 구현 [#10]

### DIFF
--- a/src/api/studyRoom/hooks.ts
+++ b/src/api/studyRoom/hooks.ts
@@ -1,12 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { createPersonalStudyRoom, createGroupStudyRoom } from '.';
+import { createPersonalStudyRoom, createGroupStudyRoom, getPersonalStudyRoomProblems } from '.';
 import { showApiErrorToast } from '../../utils/api/showApiErrorToast';
 import type {
   CreatePersonalStudyRoomBody,
   CreatePersonalStudyRoomResponse,
   CreateGroupStudyRoomBody,
   CreateGroupStudyRoomResponse,
+  PersonalStudyProblemsResponse,
 } from '../../types/studyRoom';
 import type { ApiError } from '../../types/common';
 
@@ -27,4 +28,10 @@ export const useCreateGroupStudyRoomMutation = () =>
       toast.success('그룹 스터디가 생성되었습니다.');
     },
     onError: showApiErrorToast,
+  });
+
+export const usePersonalStudyRoomProblemsQuery = (studyRoomId: number) =>
+  useQuery<PersonalStudyProblemsResponse, ApiError>({
+    queryKey: ['personal', studyRoomId, 'problems'],
+    queryFn: () => getPersonalStudyRoomProblems(studyRoomId),
   });


### PR DESCRIPTION
## 📎 Issue 번호

<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.
ex) `closed #2` -->
closed #10 

## 🚧 작업 목록

- [x] 개인 공부방 생성 뮤테이션 훅(`useCreatePersonalStudyRoomMutation`) 구현
- [x] 그룹 스터디 생성 뮤테이션 훅(`useCreateGroupStudyRoomMutation`) 구현
- [x] 개인 공부방 문제 조회 쿼리 훅(`usePersonalStudyRoomProblemsQuery`) 구현

## ✨ 작업 내용

<!-- 핵심적으로 변경된 사항들을 간략하게 체크박스로 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
1. **StudyRoom 도메인 TanStack Query 훅 구현**
   - 개인 공부방 생성(`useCreatePersonalStudyRoomMutation`)
   - 그룹 스터디 생성(`useCreateGroupStudyRoomMutation`)
   -  개인 공부방 문제 조회(`usePersonalStudyRoomProblemsQuery`)

## 🎯 리뷰 포인트

<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->

## 📝 기타

<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요.
-> 예: 임시로 처리한 부분, 후속 작업 예정, 개발한 기능의 구현 방법 등 -->
